### PR TITLE
Renaming and deleting collection dialogs on the parent collection mentions its sub collection instead

### DIFF
--- a/UI/Dialogs/DeleteWebCollectionDialog.xaml
+++ b/UI/Dialogs/DeleteWebCollectionDialog.xaml
@@ -14,7 +14,7 @@
     CloseButtonText="Cancel"
     PrimaryButtonText="Delete collection"
     PrimaryButtonClick="BaseContentDialog_PrimaryButtonClick"
-    Title="{x:Bind ViewModel.SelectedItem.Name,Mode=OneTime}">
+    Title="{x:Bind WebCollection.Name,Mode=OneTime}">
 
     <Grid>
         <TextBlock>

--- a/UI/Dialogs/RenameWebCollectionDialog.xaml
+++ b/UI/Dialogs/RenameWebCollectionDialog.xaml
@@ -17,7 +17,7 @@
     CloseButtonClick="BaseContentDialog_CloseButtonClick"
     Closing="BaseContentDialog_Closing"
     DefaultButton="Primary"
-    Title="{x:Bind ViewModel.SelectedItem.Name,Mode=OneTime}">
+    Title="{x:Bind WebCollection.Name,Mode=OneTime}">
 
     <StackPanel Orientation="Vertical">
         <TextBox x:Name="CollectionName"></TextBox>


### PR DESCRIPTION
The Title was bound to the viewmodel's selected item, which doesn't refer to the parent when editing the parent collection

Closes #11